### PR TITLE
添加 PDF 自动构建和发布工作流

### DIFF
--- a/.github/workflows/pandoc-assets/graphics-maxwidth.tex
+++ b/.github/workflows/pandoc-assets/graphics-maxwidth.tex
@@ -1,0 +1,8 @@
+% graphics-maxwidth.tex
+% 让所有图片最大宽度不超过页面内容宽度，等比缩放
+\usepackage{graphicx}
+\makeatletter
+\def\maxwidth{\ifdim\Gin@nat@width>\linewidth\linewidth\else\Gin@nat@width\fi}
+\let\Oldincludegraphics\includegraphics
+\renewcommand{\includegraphics}[2][]{\Oldincludegraphics[width=\maxwidth,#1]{#2}}
+\makeatother

--- a/.github/workflows/pandoc-assets/pandoc-gitbook-preprocess.py
+++ b/.github/workflows/pandoc-assets/pandoc-gitbook-preprocess.py
@@ -1,0 +1,49 @@
+import re
+import sys
+import os
+
+def convert_hint_blocks(text):
+    # 将 GitBook hint 块转为标准 Markdown blockquote，兼容 Pandoc 输出
+    def repl(m):
+        style = m.group(1)
+        content = m.group(2).strip()
+        style_map = {
+            "info": "信息",   
+            "warning": "警告",  
+            "danger": "注意"   
+        }
+        prefix = style_map.get(style, style)
+        # 每行加 > 前缀，首行加类型
+        lines = content.splitlines()
+        if lines:
+            lines[0] = f"**{prefix}：** " + lines[0]
+        content = "\n".join([f"> {line}" for line in lines])
+        return content + "\n"
+    return re.sub(r'{% hint style="(\w+)" %}([\s\S]*?){% endhint %}', repl, text)
+
+def convert_figure_img(text):
+    # 只识别图片 src 路径，全部替换为 .gitbook/assets/xxx，caption 只取 <p>...</p> 内容
+    def repl(m):
+        src = m.group(1)
+        filename = os.path.basename(src)
+        new_src = f'.gitbook/assets/{filename}'
+        figcaption = m.group(2)
+        # 只取 <p>...</p> 里的内容作为 caption
+        p_match = re.search(r'<p>([\s\S]*?)</p>', figcaption, re.IGNORECASE)
+        caption = p_match.group(1).strip() if p_match else ''
+        return f'![{caption}]({new_src})\n'
+    return re.sub(
+        r'<figure>\s*<img [^>]*src="([^"]+)"[^>]*>\s*<figcaption>([\s\S]*?)</figcaption>\s*</figure>',
+        repl,
+        text,
+        flags=re.IGNORECASE
+    )
+
+def main():
+    content = sys.stdin.read()
+    content = convert_hint_blocks(content)
+    content = convert_figure_img(content)
+    sys.stdout.write(content)
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/release-pdf-honkit.yml
+++ b/.github/workflows/release-pdf-honkit.yml
@@ -1,0 +1,73 @@
+name: HonKit
+
+on:
+  push:
+    tags:
+      - "v*" # 仅在推送 v 开头的标签时触发
+  workflow_dispatch: # 允许手动触发
+
+permissions:
+  contents: write # 需要写入权限来创建/上传 Release 附件
+
+jobs:
+  build_and_release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # 获取完整的 git 历史
+
+      - name: Get latest commit info
+        id: git
+        run: |
+          echo "message=$(git log -1 --pretty=%B)" >> $GITHUB_OUTPUT
+          echo "sha=$(git log -1 --pretty=%H)" >> $GITHUB_OUTPUT
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+
+      - name: Install HonKit and plugins locally
+        run: |
+          npm init -y
+          npm install honkit
+          npm install honkit-plugin-alert-msg
+          npm install gitbook-plugin-hints
+          npm install gitbook-plugin-url-embed
+
+      - name: Install Dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            calibre \
+            fonts-noto-cjk \
+            fonts-noto \
+            fonts-noto-core \
+            fonts-noto-extra \
+            fonts-noto-ui-core \
+            fonts-noto-ui-extra
+
+      - name: Create output directory
+        run: mkdir -p ./release_pdfs
+
+      - name: Build PDF with HonKit
+        run: |
+          echo "Starting PDF conversion with HonKit..."
+          npx honkit pdf ./ ./release_pdfs/mastering-bitcoin-3rd.pdf
+          echo "PDF conversion finished."
+
+      - name: Upload PDF to Release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: ./release_pdfs/*.pdf
+          tag: "${{ github.workflow }}-${{ github.ref_name }}"
+          overwrite: true # 如果已存在同名文件，则覆盖
+          file_glob: true # 启用通配符匹配
+          release_name: "精通比特币第三版-${{ github.ref_name }}"
+          body: |
+            PDF 版本：${{ github.workflow }}-${{ github.ref_name }}
+            构建用户：${{ github.actor }}
+            最近修改：[${{ steps.git.outputs.message }}](https://github.com/${{ github.repository }}/commit/${{ steps.git.outputs.sha }}) 

--- a/.github/workflows/release-pdf-pandoc.yml
+++ b/.github/workflows/release-pdf-pandoc.yml
@@ -1,0 +1,116 @@
+name: Pandoc
+
+on:
+  push:
+    tags:
+      - "v*" # 仅在推送 v 开头的标签时触发
+  workflow_dispatch: # 允许手动触发
+
+# 设置 GITHUB_TOKEN 的权限，允许创建 Release 和写入内容
+permissions:
+  contents: write # 需要写入权限来创建/上传 Release 附件
+
+jobs:
+  build_and_release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # 获取完整的 git 历史
+
+      - name: Get latest commit info
+        id: git
+        run: |
+          echo "message=$(git log -1 --pretty=%B)" >> $GITHUB_OUTPUT
+          echo "sha=$(git log -1 --pretty=%H)" >> $GITHUB_OUTPUT
+
+      - name: Install Dependencies (LaTeX, Pandoc, CJK Fonts)
+        run: |
+          sudo apt-get update
+          echo "Installing TeX Live, Pandoc, and Noto CJK Fonts. This may take a while..."
+          sudo apt-get install -y --no-install-recommends \
+            texlive-xetex \
+            texlive-lang-chinese \
+            texlive-fonts-recommended \
+            texlive-fonts-extra \
+            texlive-latex-recommended \
+            texlive-latex-extra \
+            texlive-luatex \
+            texlive-science \
+            texlive-pictures \
+            texlive-plain-generic \
+            texlive-latex-base \
+            texlive-latex-recommended \
+            texlive-latex-extra \
+            texlive-fonts-extra \
+            texlive-lang-english \
+            fonts-noto-cjk \
+            fonts-noto \
+            fonts-noto-core \
+            fonts-noto-extra \
+            fonts-noto-ui-core \
+            fonts-noto-ui-extra \
+            pandoc
+          echo "Installation complete."
+
+      - name: Create output directory
+        run: mkdir -p ./release_pdfs
+
+      - name: Download eisvogel LaTeX template
+        run: |
+          wget https://github.com/Wandmalfarbe/pandoc-latex-template/releases/download/v3.2.0/Eisvogel-3.2.0.tar.gz -O Eisvogel-3.2.0.tar.gz
+          tar -xzf Eisvogel-3.2.0.tar.gz Eisvogel-3.2.0/eisvogel.latex --strip-components=1
+
+      - name: Convert GitBook syntax to Pandoc-friendly Markdown
+        run: |
+          find . -name '*.md' | while read file; do
+            python3 $GITHUB_WORKSPACE/.github/workflows/pandoc-assets/pandoc-gitbook-preprocess.py < "$file" > "$file.tmp" && mv "$file.tmp" "$file"
+          done
+
+      - name: Set wider table column spacing for LaTeX
+        run: echo '\setlength{\tabcolsep}{10pt}' > table-space.tex
+
+      - name: Convert Markdown to PDF
+        run: |
+          echo "Starting PDF conversion..."
+          # 创建临时文件来存储文件列表
+          echo "Creating ordered file list from SUMMARY.md..."
+          grep -o '\[.*\](.*\.md)' SUMMARY.md | sed 's/\[.*\](//g' | sed 's/)$//g' > ordered_files.txt
+
+          # 创建输出目录
+          mkdir -p ./release_pdfs
+
+          # 合并所有 MD 文件为一个 PDF 文件，按 SUMMARY.md 顺序
+          echo "Converting all Markdown files to ./release_pdfs/mastering-bitcoin-3rd.pdf"
+          pandoc $(cat ordered_files.txt) -o ./release_pdfs/mastering-bitcoin-3rd.pdf \
+            --template eisvogel.latex \
+            -f markdown+pipe_tables-raw_tex \
+            --pdf-engine=xelatex \
+            --toc \
+            --toc-depth=3 \
+            -V CJKmainfont="Noto Sans CJK SC" \
+            --variable verbatim-in-note=true \
+            -V book=true \
+            -V toc-own-page=true \
+            -V header-left="精通比特币" \
+            -V header-right="第三版" \
+            -V footer-center="\\href{https://github.com/${{ github.repository }}}{${{ github.repository }}}" \
+            --include-in-header=table-space.tex \
+            --include-in-header=$GITHUB_WORKSPACE/.github/workflows/pandoc-assets/graphics-maxwidth.tex \
+            # -V watermark="仅供学习交流" \
+          echo "PDF conversion finished."
+
+      - name: Upload PDF to Release
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: ./release_pdfs/*.pdf
+          tag: "${{ github.workflow }}-${{ github.ref_name }}"
+          overwrite: true # 如果已存在同名文件，则覆盖
+          file_glob: true # 启用通配符匹配
+          release_name: "精通比特币第三版-${{ github.ref_name }}"
+          body: |
+            PDF 版本：${{ github.workflow }}-${{ github.ref_name }}
+            构建用户：${{ github.actor }}
+            最近修改：[${{ steps.git.outputs.message }}](https://github.com/${{ github.repository }}/commit/${{ steps.git.outputs.sha }})


### PR DESCRIPTION
这个 PR 添加了一个完整的 GitHub Actions 工作流，用于自动将仓库中md文件转化成pdf格式并发布。
触发方式:
1. 推送以 v 开头的标签（tag）
只要你在仓库推送一个以 v 开头的 tag（如 v1.0.0、v2.3.4），workflow 会自动运行，生成 PDF 并上传到对应 Release。

命令示例：
`git tag v1.0.0
git push origin v1.0.0`

2. 手动触发
可以在 GitHub 仓库页面的 Actions 标签页，选择本 workflow，点击 “Run workflow” 按钮，手动触发一次构建和发布。